### PR TITLE
refator data sources to gcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,17 @@
 Dataproc ML Quickstart Notebooks are an effort to assist you to jumpstart the development of data processing and machine learning notebooks using [Dataproc](https://cloud.google.com/dataproc/)'s distributed processing capabilities.  
 
 We are release a set of machine learning focused notebooks, for you to adapt, extend, and use to solve your use cases using your own data.  
-Also, we are releasing a public read-only Dataproc Metastore, for you to easily have access to several curated public datasets in this managed metastore using Spark.  
+You can easily clone the repo and start executing the notebooks right way using your Dataproc cluster or Dataproc Serverless Runtime.  
+
+The notebooks read datasets from our public GCS bucket containing several publicly available datasets.  
+We are aslo releasing a public read-only Dataproc Metastore with these datasets, if you wish to connect you Dataproc cluster or runtime with the metastore.  
 
 [![Open in Cloud Shell](http://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor)
 
 ## Public Datasets
-Please refer to [Metastore Public Datasets quickstart](./public_datasets/dataproc_metastore/metastore_public_datasets_quickstart.ipynb) to learn how you can quickly integrate your Spark application with a managed Dataproc Metastore and use one of our curated public datasets. Later on, you will be able to create your own Dataproc Metastore and centralize your own datasets.
+The public datasets are available in [gs://dataproc-metastore-public-binaries](https://console.cloud.google.com/storage/browser/dataproc-metastore-public-binaries)  
+Please refer to [Metastore Public Datasets quickstart](./public_datasets/dataproc_metastore/metastore_public_datasets_quickstart.ipynb) to see the available datasets and learn how you can quickly integrate your Spark application with a managed Dataproc Metastore.
+Also, the documentation above has details about the datasets, and links to their original pages, containing their LICENSES, etc.  
 
 ## Notebooks
 Please refer to each notebooks folder documentation for more information:

--- a/classification/linear_support_vector_machine/predictive_maintenance.ipynb
+++ b/classification/linear_support_vector_machine/predictive_maintenance.ipynb
@@ -15,7 +15,7 @@
     "\n",
     "#### **Steps**\n",
     "Using Spark, \n",
-    "1) It reads the table [AI4I 2020 Predictive Maintenance Dataset](https://doi.org/10.24432/C5HS5C) from the **public_datasets** dataset located in the [metastore](../gcp_services/README.md) (notebook should be connected with the public metastore if using this specific dataset).       \n",
+    "1) It reads the table [AI4I 2020 Predictive Maintenance Dataset](https://doi.org/10.24432/C5HS5C) dataset located in the [gs://dataproc-metastore-public-binaries/ai4i_2020_predictive_maintenance/](https://console.cloud.google.com/storage/browser/dataproc-metastore-public-binaries/ai4i_2020_predictive_maintenance)       \n",
     "2) It parses process the dataset to choose features and train the ML model (fits the classification model) to predict a target value.  \n",
     "   **Features**: air temperature [K], process temperature [K], rotational speed [rpm], torque [Nm], tool wear [min]\n",
     "   **Target**: machine failure\n",
@@ -51,11 +51,6 @@
     "  - AI Platform Notebooks Service Agent\n",
     "  - Notebooks Admin\n",
     "  - Vertex AI Administrator\n",
-    "- **Read tables from Dataproc Metastore**\n",
-    "  - Dataproc Metastore Editor\n",
-    "  - Dataproc Metastore Metadata Editor\n",
-    "  - Dataproc Metastore Metadata User\n",
-    "  - Dataproc Metastore Service Agent\n",
     "- **Read files from bucket**\n",
     "  - Storage Object Viewer\n",
     "- **Run Dataproc jobs**\n",
@@ -76,7 +71,6 @@
     "import pandas as pd\n",
     "from sklearn.metrics import confusion_matrix\n",
     "\n",
-    "\n",
     "from pyspark.ml.feature import VectorAssembler, StringIndexer, StandardScaler\n",
     "from pyspark.ml.classification import LinearSVC\n",
     "from pyspark.ml import Pipeline\n",
@@ -85,7 +79,8 @@
     "from pyspark.sql.functions import udf\n",
     "from pyspark.ml.linalg import Vectors, VectorUDT\n",
     "\n",
-    "from imblearn.over_sampling import SMOTE\n"
+    "!pip3 install imblearn --quiet\n",
+    "from imblearn.over_sampling import SMOTE"
    ]
   },
   {
@@ -94,7 +89,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pyspark.sql import SparkSession\n"
+    "from pyspark.sql import SparkSession"
    ]
   },
   {
@@ -106,7 +101,7 @@
     "spark = SparkSession.builder \\\n",
     "    .appName(\"Linear SVM Predictive Maintenance\") \\\n",
     "    .enableHiveSupport() \\\n",
-    "    .getOrCreate()\n"
+    "    .getOrCreate()"
    ]
   },
   {
@@ -115,7 +110,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "raw_dataset = spark.read.table(\"public_datasets.ai4i_2020_predictive_maintenance\")\n"
+    "raw_dataset = spark.read.option(\"header\", True).csv(\"gs://dataproc-metastore-public-binaries/ai4i_2020_predictive_maintenance/\")"
    ]
   },
   {
@@ -136,7 +131,7 @@
     "\n",
     "# Calculate and display the class distribution\n",
     "total_count = raw_dataset.count()\n",
-    "class_counts.withColumn('Percentage', (class_counts['count'] / total_count) * 100).show()\n"
+    "class_counts.withColumn('Percentage', (class_counts['count'] / total_count) * 100).show()"
    ]
   },
   {
@@ -169,7 +164,7 @@
     "# convert numerical features to float\n",
     "for column in filtered_dataset.columns:\n",
     "  if column != \"type\":\n",
-    "    filtered_dataset = filtered_dataset.withColumn(column, filtered_dataset[column].cast(\"float\"))\n"
+    "    filtered_dataset = filtered_dataset.withColumn(column, filtered_dataset[column].cast(\"float\"))"
    ]
   },
   {
@@ -179,7 +174,7 @@
    "outputs": [],
    "source": [
     "# StringIndexer to convert string labels to numerical labels\n",
-    "type_indexer = StringIndexer(inputCol=\"type\", outputCol=\"type_index\")\n"
+    "type_indexer = StringIndexer(inputCol=\"type\", outputCol=\"type_index\")"
    ]
   },
   {
@@ -190,7 +185,7 @@
    "source": [
     "# Assemble features into a single column\n",
     "feature_cols = [\"type_index\", \"air_temperature_k\", \"process_temperature_k\", \"rotational_speed_rpm\", \"torque_nm\", \"tool_wear_min\"]\n",
-    "assembler = VectorAssembler(inputCols=feature_cols, outputCol=\"features\")\n"
+    "assembler = VectorAssembler(inputCols=feature_cols, outputCol=\"features\")"
    ]
   },
   {
@@ -200,7 +195,7 @@
    "outputs": [],
    "source": [
     "# Standardize features\n",
-    "scaler = StandardScaler(inputCol=\"features\", outputCol=\"scaled_features\", withStd=True, withMean=True)\n"
+    "scaler = StandardScaler(inputCol=\"features\", outputCol=\"scaled_features\", withStd=True, withMean=True)"
    ]
   },
   {
@@ -212,7 +207,7 @@
     "# Create a pipeline to execute the preprocessing and modeling steps\n",
     "prep_pipeline = Pipeline(stages=[type_indexer, assembler, scaler])\n",
     "\n",
-    "processed_dataset = prep_pipeline.fit(filtered_dataset).transform(filtered_dataset)\n"
+    "processed_dataset = prep_pipeline.fit(filtered_dataset).transform(filtered_dataset)"
    ]
   },
   {
@@ -221,7 +216,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset = processed_dataset.select(\"scaled_features\", \"machine_failure\")\n"
+    "dataset = processed_dataset.select(\"scaled_features\", \"machine_failure\")"
    ]
   },
   {
@@ -230,7 +225,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset.show(5)\n"
+    "dataset.show(5)"
    ]
   },
   {
@@ -269,7 +264,7 @@
     "pipeline = Pipeline(stages=[svm])\n",
     "\n",
     "# Train the model\n",
-    "model = pipeline.fit(train_data)\n"
+    "model = pipeline.fit(train_data)"
    ]
   },
   {
@@ -293,7 +288,7 @@
     "area_under_roc = evaluator.evaluate(predictions)\n",
     "\n",
     "# Print the Area Under ROC\n",
-    "print(\"Area Under ROC: \" + str(area_under_roc))\n"
+    "print(\"Area Under ROC: \" + str(area_under_roc))"
    ]
   },
   {
@@ -337,7 +332,7 @@
     "class_names = [\"No failure\", \"Failure\"]\n",
     "plot_confusion_matrix(confusion, classes=class_names, title=\"Confusion Matrix\")\n",
     "\n",
-    "plt.show()\n"
+    "plt.show()"
    ]
   },
   {
@@ -365,7 +360,7 @@
     "X_resampled, y_resampled = smote.fit_resample(pandas_df[\"scaled_features\"].apply(lambda x: x.toArray()).values.tolist(), pandas_df[\"machine_failure\"])\n",
     "\n",
     "# Create a new DataFrame from the resampled data\n",
-    "resampled_dataset = spark.createDataFrame(pd.DataFrame({\"scaled_features\": X_resampled, \"machine_failure\": y_resampled}))\n"
+    "resampled_dataset = spark.createDataFrame(pd.DataFrame({\"scaled_features\": X_resampled, \"machine_failure\": y_resampled}))"
    ]
   },
   {
@@ -379,7 +374,7 @@
     "\n",
     "# Calculate and display the class distribution\n",
     "total_count = resampled_dataset.count()\n",
-    "class_counts.withColumn('Percentage', (class_counts['count'] / total_count) * 100).show()\n"
+    "class_counts.withColumn('Percentage', (class_counts['count'] / total_count) * 100).show()"
    ]
   },
   {
@@ -400,7 +395,7 @@
    "source": [
     "# Define a UDF to convert ArrayType to VectorUDT\n",
     "array_to_vector_udf = udf(lambda arr: Vectors.dense(arr), VectorUDT())\n",
-    "resampled_dataset = resampled_dataset.withColumn(\"scaled_features\", array_to_vector_udf(\"scaled_features\"))\n"
+    "resampled_dataset = resampled_dataset.withColumn(\"scaled_features\", array_to_vector_udf(\"scaled_features\"))"
    ]
   },
   {
@@ -425,7 +420,7 @@
     "pipeline = Pipeline(stages=[svm])\n",
     "\n",
     "# Train the model\n",
-    "model = pipeline.fit(train_data)\n"
+    "model = pipeline.fit(train_data)"
    ]
   },
   {
@@ -449,7 +444,7 @@
     "area_under_roc = evaluator.evaluate(predictions)\n",
     "\n",
     "# Print the Area Under ROC\n",
-    "print(\"Area Under ROC: \" + str(area_under_roc))\n"
+    "print(\"Area Under ROC: \" + str(area_under_roc))"
    ]
   },
   {
@@ -493,7 +488,7 @@
     "class_names = [\"No failure\", \"Failure\"]\n",
     "plot_confusion_matrix(confusion, classes=class_names, title=\"Confusion Matrix\")\n",
     "\n",
-    "plt.show()\n"
+    "plt.show()"
    ]
   },
   {
@@ -503,15 +498,15 @@
    "outputs": [],
    "source": [
     "# Stop the Spark session\n",
-    "spark.stop()\n"
+    "spark.stop()"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "PySpark on cluster-with-metastore-bq (Remote)",
+   "display_name": "Python 3 on cluster-dpms (Remote)",
    "language": "python",
-   "name": "9b6844836fbacc61a012fc97-pyspark"
+   "name": "7a42ae6b283a613cfabce6f7-python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -523,10 +518,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.15"
-  },
-  "orig_nbformat": 4
+   "version": "3.10.8"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/classification/logistic_regression/wine_quality_classification_mlr.ipynb
+++ b/classification/logistic_regression/wine_quality_classification_mlr.ipynb
@@ -103,16 +103,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d7aefa1a-12f7-41cd-81d6-f94610f157b7",
+   "metadata": {},
    "outputs": [],
    "source": [
-    "df = spark.read.table(\"public_datasets.winequality_white\")"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+    "df = spark.read.option(\"header\", True).csv(\"gs://dataproc-metastore-public-binaries/winequality_white/\")"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "0690c904",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "source": [
     "|fixed_acidity|volatile_acidity|citric_acid|residual_sugar|chlorides|free_sulfur_dioxide|total_sulfur_dioxide|density|  pH|sulphates|alcohol|quality|\n",
     "|-------------|----------------|-----------|--------------|---------|-------------------|--------------------|-------|----|---------|-------|-------|\n",
@@ -121,10 +127,7 @@
     "|          8.1|            0.28|        0.4|           6.9|     0.05|               30.0|                97.0| 0.9951|3.26|     0.44|   10.1|      6|\n",
     "|          7.2|            0.23|       0.32|           8.5|    0.058|               47.0|               186.0| 0.9956|3.19|      0.4|    9.9|      6|\n",
     "|          7.2|            0.23|       0.32|           8.5|    0.058|               47.0|               186.0| 0.9956|3.19|      0.4|    9.9|      6|"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -135,13 +138,14 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "4c94e725-fedf-4eef-9ba7-b3b8810f3012",
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b1fab229-deb4-49e8-8754-3b03f707a098",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "DataFrames may have heterogenous or \"mixed\" data types, that is, some columns are numbers, some are strings, and some are dates etc. Because CSV files do not contain information on what data types are contained in each column, Pandas infers the data types when loading the data, e.g. if a column contains only numbers, Pandas will set that column’s data type to numeric: integer or float.\n",
-    "\n",
-    "Run the next cell to see information on the DataFrame."
+    "df = df.select(*(col(c).cast(\"float\").alias(c) for c in df.columns))\n",
+    "df = df.withColumn(\"quality\", col(\"quality\").cast(\"int\"))"
    ]
   },
   {
@@ -292,53 +296,6 @@
     "Great part of freatures had a normal distribution, also known as the Gaussian distribution, is a continuous probability distribution that is widely used in statistical modeling and machine learning. It is a bell-shaped curve that is symmetrical around its mean and is characterized by its mean and standard deviation.\n",
     "\n",
     "In machine learning, data that is normally distributed is beneficial for model building because it makes the math easier. Many machine learning algorithms, such as linear regression and logistic regression, are explicitly calculated from the assumption that the distribution is a bivariate or multivariate normal. Additionally, sigmoid functions work most naturally with normally distributed data."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fa1f18b8-5879-43c2-b04b-df45061210eb",
-   "metadata": {},
-   "source": [
-    "### Rename a Feature Column "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1c7de40f-ec11-4232-b165-967d013eb27e",
-   "metadata": {},
-   "source": [
-    "Our feature columns have different \"capitalizations\" in their names, e.g. both upper and lower \"case\".  In addition, there are \"spaces\" in some of the column names. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "19730bcd-71c5-4247-b0af-3da9932b3f89",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df = df.withColumnRenamed(\"fixed acidity\",\"fixed_acidity\")\\\n",
-    ".withColumnRenamed(\"volatile acidity\",\"volatile_acidity\")\\\n",
-    ".withColumnRenamed(\"citric acid\",\"citric_acid\")\\\n",
-    ".withColumnRenamed(\"residual sugar\",\"residual_sugar\")\\\n",
-    ".withColumnRenamed(\"chlorides\",\"chlorides\")\\\n",
-    ".withColumnRenamed(\"free sulfur dioxide\",\"free_sulfur_dioxide\")\\\n",
-    ".withColumnRenamed(\"total sulfur dioxide\",\"total_sulfur_dioxide\")\\\n",
-    ".withColumnRenamed(\"density\",\"density\")\\\n",
-    ".withColumnRenamed(\"pH\",\"pH\")\\\n",
-    ".withColumnRenamed(\"sulphates\",\"sulphates\")\\\n",
-    ".withColumnRenamed(\"alcohol\",\"alcohol\")\\\n",
-    ".withColumnRenamed(\"quality\",\"quality\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ad4177e6-249b-4b30-aa4f-f152898d2fbc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df.printSchema()"
    ]
   },
   {
@@ -864,6 +821,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 on cluster-dpms (Remote)",
+   "language": "python",
+   "name": "7a42ae6b283a613cfabce6f7-python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -874,12 +836,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.15"
-  },
-  "kernelspec": {
-   "name": "9b6844836fbacc61a012fc97-python3",
-   "language": "python",
-   "display_name": "Python 3 on cluster-with-metastore-bq (Remote)"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/classification/multilayer_perceptron_classifier/sms_spam_filtering.ipynb
+++ b/classification/multilayer_perceptron_classifier/sms_spam_filtering.ipynb
@@ -15,7 +15,7 @@
     "\n",
     "#### **Steps**\n",
     "Using Spark, \n",
-    "1) It reads the table [SMS Spam Collection](https://doi.org/10.24432/C5CC84) from the **public_datasets** dataset located in the [metastore](../gcp_services/README.md) (notebook should be connected with the public metastore if using this specific dataset).       \n",
+    "1) It reads the table [SMS Spam Collection](https://doi.org/10.24432/C5CC84) from [gs://dataproc-metastore-public-binaries/sms_spam_collection/](https://console.cloud.google.com/storage/browser/dataproc-metastore-public-binaries/sms_spam_collection) \n",
     "2) It parses process the dataset to choose features and train the ML model (fits the classification model) to predict a target value.  \n",
     "   **Features**: text\n",
     "   **Target**: spam or ham \n",
@@ -52,11 +52,6 @@
     "  - AI Platform Notebooks Service Agent\n",
     "  - Notebooks Admin\n",
     "  - Vertex AI Administrator\n",
-    "- **Read tables from Dataproc Metastore**\n",
-    "  - Dataproc Metastore Editor\n",
-    "  - Dataproc Metastore Metadata Editor\n",
-    "  - Dataproc Metastore Metadata User\n",
-    "  - Dataproc Metastore Service Agent\n",
     "- **Read files from bucket**\n",
     "  - Storage Object Viewer\n",
     "- **Run Dataproc jobs**\n",
@@ -110,7 +105,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "raw_dataset = spark.read.table(\"public_datasets.sms_spam_collection\")"
+    "raw_dataset = spark.read.option(\"header\",True).csv(\"gs://dataproc-metastore-public-binaries/sms_spam_collection/\")"
    ]
   },
   {
@@ -131,7 +126,7 @@
     "\n",
     "# Calculate and display the class distribution\n",
     "total_count = raw_dataset.count()\n",
-    "class_counts.withColumn('Percentage', (class_counts['count'] / total_count) * 100).show()\n"
+    "class_counts.withColumn('Percentage', (class_counts['count'] / total_count) * 100).show()"
    ]
   },
   {
@@ -352,9 +347,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "PySpark on cluster-with-metastore-bq (Remote)",
+   "display_name": "Python 3 on cluster-dpms (Remote)",
    "language": "python",
-   "name": "9b6844836fbacc61a012fc97-pyspark"
+   "name": "7a42ae6b283a613cfabce6f7-python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -366,7 +361,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.15"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/generative_ai/content_generation/product_attributes_from_image.ipynb
+++ b/generative_ai/content_generation/product_attributes_from_image.ipynb
@@ -65,9 +65,8 @@
    "source": [
     "#### **Steps**\n",
     "Using Spark,\n",
-    "1) It reads a metadata table of the [Stanford Online Products dataset](https://cvgl.stanford.edu/projects/lifted_struct/) from the **public_datasets** dataset located in the [metastore](../../public_datasets/dataproc_metastore/metastore_public_datasets_quickstart.ipynb) (notebook should be connected with the public metastore if using this specific dataset).\n",
-    "This metadata table contains the paths of the image files in the bucket.\n",
-    "If you want to apply this to a different dataset, you can read the pdf files in your bucket with spark.read.format(\"binaryFile\") (no need of the metastore) - more details [here](../../public_datasets/dataproc_metastore/metastore_public_datasets_quickstart.ipynb).\n",
+    "1) It reads the table of the [Stanford Online Products dataset](https://cvgl.stanford.edu/projects/lifted_struct/) dataset located in [gs://dataproc-metastore-public-binaries/stanford_online_products](https://console.cloud.google.com/storage/browser/dataproc-metastore-public-binaries/stanford_online_products)    \n",
+    "We will create a metadata table poiting to the paths of the image files in the bucket.  \n",
     "2) It calls Vertex AI Imagen for Captioning and VQA to get product attributes for each image.\n",
     "3) It calls Vertex AI Gemini API to get product sales descriptions based on the image."
    ]
@@ -89,11 +88,6 @@
     "  - AI Platform Notebooks Service Agent\n",
     "  - Notebooks Admin\n",
     "  - Vertex AI Administrator\n",
-    "- **Read tables from Dataproc Metastore**\n",
-    "  - Dataproc Metastore Editor\n",
-    "  - Dataproc Metastore Metadata Editor\n",
-    "  - Dataproc Metastore Metadata User\n",
-    "  - Dataproc Metastore Service Agent\n",
     "- **Read files from bucket**\n",
     "  - Storage Object Viewer\n",
     "- **Run Dataproc jobs**\n",
@@ -239,8 +233,8 @@
    },
    "outputs": [],
    "source": [
-    "### Read the dataset from the public Dataproc Metastore connected\n",
-    "binaries_df = spark.read.table(\"public_datasets.stanford_online_products\")"
+    "BINARIES_BUCKET_PATH = \"gs://dataproc-metastore-public-binaries/stanford_online_products/\"\n",
+    "binaries_df = spark.read.format(\"binaryFile\").option(\"recursiveFileLookup\", \"true\").load(BINARIES_BUCKET_PATH)"
    ]
   },
   {
@@ -254,24 +248,22 @@
    },
    "outputs": [],
    "source": [
-    "### Another option is to read from the bucket directly\n",
-    "# BINARIES_BUCKET_PATH = \"gs://dataproc-metastore-public-binaries/stanford_online_products/\"\n",
-    "# binaries_df = spark.read.format(\"binaryFile\").option(\"recursiveFileLookup\", \"true\").load(BINARIES_BUCKET_PATH)"
+    "# Let's select the paths of the first 10 product images\n",
+    "paths_df = binaries_df.select(\"path\").limit(10)\n",
+    "paths_df.cache()"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
-   },
-   "outputs": [],
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
-    "# Let's select the paths of the first 100 product images\n",
-    "paths_df = binaries_df.select(\"path\").limit(5)"
+    "|                                                                                          path|\n",
+    "|----------------------------------------------------------------------------------------------|\n",
+    "|gs://dataproc-metastore-public-binaries/stanford_online_products/sofa_final/181714736872_0.JPG|\n",
+    "|gs://dataproc-metastore-public-binaries/stanford_online_products/sofa_final/181661485577_1.JPG|\n",
+    "|gs://dataproc-metastore-public-binaries/stanford_online_products/sofa_final/171860974117_1.JPG|\n",
+    "|gs://dataproc-metastore-public-binaries/stanford_online_products/sofa_final/171860974117_2.JPG|\n",
+    "|gs://dataproc-metastore-public-binaries/stanford_online_products/sofa_final/181661485577_0.JPG|"
    ]
   },
   {
@@ -598,9 +590,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 on cluster-with-metastore-bq (Remote)",
+   "display_name": "Python 3 on cluster-dpms (Remote)",
    "language": "python",
-   "name": "9b6844836fbacc61a012fc97-python3"
+   "name": "7a42ae6b283a613cfabce6f7-python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -612,7 +604,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.15"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/generative_ai/sentiment_analysis/sentiment_analysis_movie_reviews.ipynb
+++ b/generative_ai/sentiment_analysis/sentiment_analysis_movie_reviews.ipynb
@@ -500,9 +500,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 on cluster-with-metastore-bq (Remote)",
+   "display_name": "Python 3 on cluster-dpms (Remote)",
    "language": "python",
-   "name": "9b6844836fbacc61a012fc97-python3"
+   "name": "7a42ae6b283a613cfabce6f7-python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -514,7 +514,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.15"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/generative_ai/summarization/ocr_contract_summarization_llm.ipynb
+++ b/generative_ai/summarization/ocr_contract_summarization_llm.ipynb
@@ -61,9 +61,8 @@
     "\n",
     "#### **Steps**\n",
     "Using Spark, \n",
-    "1) It reads a metadata table of the [Contract Understanding Atticus Dataset (CUAD)](https://www.atticusprojectai.org/cuad) from the **public_datasets** dataset located in the [metastore](../gcp_services/README.md) (notebook should be connected with the public metastore if using this specific dataset).    \n",
-    "   This metadata table contains the paths of the pdf files in the bucket.  \n",
-    "   If you want to apply this to a different dataset, you can read the pdf files in your bucket with spark.read.format(\"binaryFile\") (no need of the metastore) - more details [here](../gcp_services/README.md). \n",
+    "1) It reads the table of the [Contract Understanding Atticus Dataset (CUAD)](https://www.atticusprojectai.org/cuad) dataset located in the [gs://dataproc-metastore-public-binaries/cuad_v1/full_contract_pdf/](https://console.cloud.google.com/storage/browser/dataproc-metastore-public-binaries/cuad_v1)  \n",
+    "   We will create a metadata table poiting to the paths of the image files in the bucket.  \n",
     "2) It runs OCR using Vision API - it start a series of async operations and then checks its completion status.\n",
     "3) It calls [Vertex AI PaLM API](https://cloud.google.com/vertex-ai/docs/generative-ai/start/quickstarts/api-quickstart#try_text_prompts) to summarize each text page.\n",
     "4) It saves the output to BigQuery\n",
@@ -105,11 +104,6 @@
     "  - AI Platform Notebooks Service Agent\n",
     "  - Notebooks Admin\n",
     "  - Vertex AI Administrator\n",
-    "- **Read tables from Dataproc Metastore**\n",
-    "  - Dataproc Metastore Editor\n",
-    "  - Dataproc Metastore Metadata Editor\n",
-    "  - Dataproc Metastore Metadata User\n",
-    "  - Dataproc Metastore Service Agent\n",
     "- **Read files from bucket**\n",
     "  - Storage Object Viewer\n",
     "- **Run Dataproc jobs**\n",
@@ -228,8 +222,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# PDFs\n",
-    "input_dataset_table = \"public_datasets.cuad_v1\"\n",
     "# Change the maximum number of files you want to consider\n",
     "limit_files = 5\n",
     "# OCR\n",
@@ -268,7 +260,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cuad_v1_df = spark.read.table(input_dataset_table).limit(limit_files)"
+    "BINARIES_BUCKET_PATH = \"gs://dataproc-metastore-public-binaries/cuad_v1/full_contract_pdf/\"\n",
+    "cuad_v1_df = spark.read.format(\"binaryFile\").option(\"recursiveFileLookup\", \"true\").load(BINARIES_BUCKET_PATH).limit(limit_files)"
    ]
   },
   {
@@ -824,9 +817,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 on cluster-with-metastore-bq (Remote)",
+   "display_name": "Python 3 on cluster-dpms (Remote)",
    "language": "python",
-   "name": "9b6844836fbacc61a012fc97-python3"
+   "name": "7a42ae6b283a613cfabce6f7-python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -838,7 +831,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.15"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/public_datasets/dataproc_metastore/metastore_public_datasets_quickstart.ipynb
+++ b/public_datasets/dataproc_metastore/metastore_public_datasets_quickstart.ipynb
@@ -37,7 +37,7 @@
     }
    },
    "source": [
-    "# Dataproc Metastore - Public Datasets Quickstart"
+    "# Public Datasets Quickstart"
    ]
   },
   {
@@ -52,18 +52,37 @@
   },
   {
    "cell_type": "markdown",
+   "id": "53a05bf0-750b-4264-9bc4-3cbf1bed93c9",
+   "metadata": {},
+   "source": [
+    "#### Datasets in the public read-only bucket\n",
+    "\n",
+    "The following GCS bucket contains the files for each available dataset detailed below.   \n",
+    "\n",
+    "|                GCP_PROJECT  |                                                                                                                    GCS bucket|\n",
+    "|-----------------------------|------------------------------------------------------------------------------------------------------------------------------|\n",
+    "|dataproc-workspaces-notebooks|[gs://dataproc-metastore-public-binaries](https://console.cloud.google.com/storage/browser/dataproc-metastore-public-binaries)|"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "d9a4c073-9967-447a-b32e-1db752f6be3b",
    "metadata": {
     "tags": []
    },
    "source": [
-    "#### **Dataproc Metastore service**\n",
+    "#### Datasets in the public Dataproc Metastore instance\n",
     "\n",
     "Dataproc Metastore is a fully managed, highly available, autohealing, serverless, Apache Hive metastore (HMS) that runs on Google Cloud.\n",
+    "Dataproc Metastore provides you with a fully compatible Hive Metastore (HMS), which is the established standard in the open source big data ecosystem for managing technical metadata. This service helps you manage the metadata of your data lakes and provides interoperability between the various data processing engines and tools you're using. [Dataproc Metastore service documentation](https://cloud.google.com/dataproc-metastore/docs/overview)\n",
+    "We are making available a public dataset in a public Dataproc Metastore, which all users can read-only several pre-loaded datasets, to facilitate reading pre-selected public datasets from the internet and leveraging Dataproc capabilities.  \n",
     "\n",
-    "Dataproc Metastore provides you with a fully compatible Hive Metastore (HMS), which is the established standard in the open source big data ecosystem for managing technical metadata. This service helps you manage the metadata of your data lakes and provides interoperability between the various data processing engines and tools you're using.\n",
-    "\n",
-    "[Dataproc Metastore service documentation](https://cloud.google.com/dataproc-metastore/docs/overview)"
+    "|                path|    modificationTime|\n",
+    "|--------------------|--------------------|\n",
+    "|GCP_PROJECT|dataproc-workspaces-notebooks  |\n",
+    "|NAME|public-metastore-v1 |\n",
+    "|LOCATION|us-central1|\n",
+    "|VERSION|3.1.2|"
    ]
   },
   {
@@ -81,110 +100,85 @@
    "id": "0ff517c8-d14d-4fab-8230-8897eef660a2",
    "metadata": {},
    "source": [
-    "[**public_datasets.cuad_v1**](https://www.atticusprojectai.org/cuad)  \n",
-    "510 PDF files of legal contracts  \n",
+    "[**cuad_v1**](https://www.atticusprojectai.org/cuad)   \n",
+    "GCS bucket path: gs://dataproc-metastore-public-binaries/cuad_v1/full_contract_pdf/    \n",
+    "Format: .pdf  \n",
+    "Metastore referece: public_datasets.cuad_v1  \n",
+    "Description: 510 PDF files of legal contracts   \n",
     " \n",
     "|                path|    modificationTime| length|             content|\n",
     "|--------------------|--------------------|-------|--------------------|\n",
     "|gs://dataproc-met...|2023-05-15 20:53:...|3683550|[25 50 44 46 2D 3...|\n",
     "\n",
-    "[**public_datasets.winequality_red**](https://archive.ics.uci.edu/dataset/186/wine+quality)  \n",
-    "4898 Wine quality data of white vinho verde samples  \n",
+    "[**winequality_red**](https://archive.ics.uci.edu/dataset/186/wine+quality)   \n",
+    "GCS bucket path: gs://dataproc-metastore-public-binaries/winequality_red/  \n",
+    "Format: .csv    \n",
+    "Metastore referece: public_datasets.winequality_red  \n",
+    "Description: 4898 Wine quality data of white vinho verde samples   \n",
     "\n",
     "|fixed_acidity|volatile_acidity|citric_acid|residual_sugar|chlorides|free_sulfur_dioxide|total_sulfur_dioxide|density|  pH|sulphates|alcohol|quality|\n",
     "|-------------|----------------|-----------|--------------|---------|-------------------|--------------------|-------|----|---------|-------|-------|\n",
     "|          7.0|            0.27|       0.36|          20.7|    0.045|               45.0|               170.0|  1.001| 3.0|     0.45|    8.8|      6|\n",
     "\n",
-    "[**public_datasets.winequality_white**](https://archive.ics.uci.edu/dataset/186/wine+quality)  \n",
-    "1599 Wine quality data of red vinho verde samples  \n",
+    "[**winequality_white**](https://archive.ics.uci.edu/dataset/186/wine+quality)   \n",
+    "GCS bucket path: gs://dataproc-metastore-public-binaries/winequality_white/    \n",
+    "Format: .csv    \n",
+    "Metastore referece: public_datasets.winequality_white  \n",
+    "Description: 1599 Wine quality data of red vinho verde samples  \n",
     "\n",
     "|fixed_acidity|volatile_acidity|citric_acid|residual_sugar|chlorides|free_sulfur_dioxide|total_sulfur_dioxide|density|  pH|sulphates|alcohol|quality|\n",
     "|-------------|----------------|-----------|--------------|---------|-------------------|--------------------|-------|----|---------|-------|-------|\n",
     "|          7.0|            0.27|       0.36|          20.7|    0.045|               45.0|               170.0|  1.001| 3.0|     0.45|    8.8|      6|\n",
     "\n",
+    "[**real_estate_sales**](https://catalog.data.gov/dataset/real-estate-sales-2001-2018)  \n",
+    "GCS bucket path: gs://dataproc-metastore-public-binaries/real_estate_sales/    \n",
+    "Format: .parquet      \n",
+    "Metastore referece: public_datasets.real_estate_sales  \n",
+    "Description: 997213 samples of real estate sales    \n",
     "\n",
-    "[**public_datasets.real_estate_sales**](https://catalog.data.gov/dataset/real-estate-sales-2001-2018)  \n",
-    "997213 samples of real estate sales  \n",
+    "| serial_number | list_year | date_recorded | town    | address      | assessed_value | sale_amount | sales_ratio | property_type | residential_type | non_use_code | assessor_remarks | opm_remarks          | longitude           | latitude           |\n",
+    "|---------------|-----------|---------------|---------|--------------|----------------|-------------|-------------|---------------|------------------|--------------|------------------|----------------------|---------------------|--------------------|\n",
+    "| 200594        | 2020      | 2021-02-16    | Danbury | 8 HICKORY ST | 121600.0       | 146216.0    | 0.8316463   | Residential   | Single Family    | 25 - Other   | I11192           | HOUSE HAS SETTLED... |            -73.44696|           41.41422 |\n",
     "\n",
-    "| serial_number | list_year | date_recorded | town    | address      | assessed_value | sale_amount | sales_ratio | property_type | residential_type | non_use_code | assessor_remarks | opm_remarks          | location            |\n",
-    "|---------------|-----------|---------------|---------|--------------|----------------|-------------|-------------|---------------|------------------|--------------|------------------|----------------------|---------------------|\n",
-    "| 200594        | 2020      | 2021-02-16    | Danbury | 8 HICKORY ST | 121600.0       | 146216.0    | 0.8316463   | Residential   | Single Family    | 25 - Other   | I11192           | HOUSE HAS SETTLED... | {-73.44696, 41.41.. |\n",
-    "\n",
-    "[**public_datasets.sms_spam_collection**](https://archive.ics.uci.edu/dataset/228/sms+spam+collection)  \n",
-    "5574 SMS messages (4827 ham and 747 spam)  \n",
+    "[**sms_spam_collection**](https://archive.ics.uci.edu/dataset/228/sms+spam+collection)  \n",
+    "GCS bucket path: gs://dataproc-metastore-public-binaries/sms_spam_collection/    \n",
+    "Format: .csv    \n",
+    "Metastore referece: public_datasets.sms_spam_collection   \n",
+    "Description: 5574 SMS messages (4827 ham and 747 spam)  \n",
     "\n",
     "|label|                text|\n",
     "|-----|--------------------|\n",
     "|  ham|Go until jurong p...|\n",
     "\n",
-    "[**public_datasets.us_customer_price_index_yearly**](https://data.bls.gov/timeseries/CUUR0000SA0L1E?output_view=pct_12mths)  \n",
-    "Customer Price Indexes from 1913 to 2022  \n",
+    "[**us_customer_price_index_yearly**](https://data.bls.gov/timeseries/CUUR0000SA0L1E?output_view=pct_12mths)  \n",
+    "GCS bucket path: gs://dataproc-metastore-public-binaries/us_customer_price_index_yearly/    \n",
+    "Format: .csv    \n",
+    "Metastore referece: public_datasets.us_customer_price_index_yearly   \n",
+    "Description: Customer Price Indexes from 1913 to 2022  \n",
     "\n",
     "| Year | CPI   |\n",
     "|------|-------|\n",
     "| 2022 | 297.0 |\n",
     "\n",
-    "[**public_datasets.ai4i_2020_predictive_maintenance**](https://archive.ics.uci.edu/dataset/601/ai4i+2020+predictive+maintenance+dataset)  \n",
-    "10000 data points stored as rows with 14 features in columns  \n",
+    "[**ai4i_2020_predictive_maintenance**](https://archive.ics.uci.edu/dataset/601/ai4i+2020+predictive+maintenance+dataset)  \n",
+    "GCS bucket path: gs://dataproc-metastore-public-binaries/ai4i_2020_predictive_maintenance/    \n",
+    "Format: .csv    \n",
+    "Metastore referece: public_datasets.ai4i_2020_predictive_maintenance   \n",
+    "Description: 10000 data points stored as rows with 14 features in columns   \n",
     "\n",
     "|udi|product_id|type|air_temperature_k|process_temperature_k|rotational_speed_rpm|torque_nm|tool_wear_min|machine_failure|twf|hdf|pwf|osf|rnf|\n",
     "|---|----------|----|-----------------|---------------------|--------------------|---------|-------------|---------------|---|---|---|---|---|\n",
     "|  1|    M14860|   M|            298.1|                308.6|                1551|     42.8|            0|              0|  0|  0|  0|  0|  0| 97.0 |\n",
     "\n",
-    "[**public_datasets.stanford_online_products**](https://cvgl.stanford.edu/projects/lifted_struct/)  \n",
-    "120k images of 23k classes of online products  \n",
+    "[**stanford_online_products**](https://cvgl.stanford.edu/projects/lifted_struct/)   \n",
+    "GCS bucket path: gs://dataproc-metastore-public-binaries/stanford_online_products/    \n",
+    "Format: .jpg    \n",
+    "Metastore referece: public_datasets.stanford_online_products   \n",
+    "Description: 120k images of 23k classes of online products   \n",
     "\n",
     "|                path|    modificationTime| length|\n",
     "|--------------------|--------------------|-------|\n",
     "|gs://dataproc-met...|2023-12-12 20:45:...|3051905|"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fcf77c49-fbbc-4a5f-8660-e7d479645829",
-   "metadata": {},
-   "source": [
-    "#### Binary data in the public GCS bucket"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "aac66727-854a-4889-8422-5708b0939d66",
-   "metadata": {},
-   "source": [
-    "- **cuad_v1**: gs://dataproc-metastore-public-binaries/cuad_v1/\n",
-    "- **stanford_online_products**: gs://dataproc-metastore-public-binaries/stanford_online_products/"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1f077669-09c4-4ae8-a33c-5debeb4c5c49",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "### About Dataproc Metastore Public Datasets"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "98bfac83-20f9-4418-9f77-96b12928cb24",
-   "metadata": {},
-   "source": [
-    "We are making available a public dataset in a public Dataproc Metastore, which all users can read-only several pre-loaded datasets, to facilitate reading pre-selected public datasets from the internet and leveraging Dataproc capabilities."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "803fb973-8149-4fbf-a887-6f03307b7c02",
-   "metadata": {},
-   "source": [
-    "|                path|    modificationTime|\n",
-    "|--------------------|--------------------|\n",
-    "|GCP_PROJECT|dataproc-workspaces-notebooks  |\n",
-    "|NAME|public-metastore-v1 |\n",
-    "|LOCATION|us-central1|\n",
-    "|VERSION|3.1.2|"
    ]
   },
   {
@@ -424,13 +418,13 @@
    "id": "ed9b6574-a1b3-4e95-8a6c-715cc337b56b",
    "metadata": {},
    "source": [
-    "| serial_number | list_year | date_recorded | town    | address              | assessed_value | sale_amount | sales_ratio | property_type | residential_type | non_use_code         | assessor_remarks     | opm_remarks          | location             |\n",
-    "|---------------|-----------|---------------|---------|----------------------|----------------|-------------|-------------|---------------|------------------|----------------------|----------------------|----------------------|----------------------|\n",
-    "| 200594        | 2020      | 2021-02-16    | Danbury | 8 HICKORY ST         | 121600.0       | 146216.0    | 0.8316463   | Residential   | Single Family    | 25 - Other           | I11192               | HOUSE HAS SETTLED... | {-73.44696, 41.41... |\n",
-    "| 200562        | 2020      | 2021-02-03    | Danbury | 19  MILL RD          | 263600.0       | 415000.0    | 0.6351807   | Residential   | Single Family    | 25 - Other           | AFFORDABLE HOUSIN... | INCORRECT DATA PE... | {-73.53692, 41.38... |\n",
-    "| 200968        | 2020      | 2021-05-24    | Danbury | 4A FLIRTATION DR     | 205700.0       | 515000.0    | 0.3994175   | Residential   | Single Family    | 07 - Change in Pr... | B17008               | UPDATED KITCHEN P... | {null, null}         |\n",
-    "| 200260        | 2020      | 2020-11-23    | Danbury | 32 COALPIT HILL R... | 84900.0        | 181778.0    | 0.4670532   | Residential   | Condo            | 25 - Other           | J16087-4             | MULTIPLE UNIT SALE   | {-73.43796, 41.38... |\n",
-    "| 200262        | 2020      | 2020-11-23    | Danbury | 32 COALPIT HILL R... | 84900.0        | 181778.0    | 0.4670532   | Residential   | Condo            | 25 - Other           | J16087-6             | MULTIPLE UNIT SALE   | {-73.43796, 41.38... |"
+    "| serial_number | list_year | date_recorded | town    | address              | assessed_value | sale_amount | sales_ratio | property_type | residential_type | non_use_code         | assessor_remarks     | opm_remarks          | longitude            | latitude           |\n",
+    "|---------------|-----------|---------------|---------|----------------------|----------------|-------------|-------------|---------------|------------------|----------------------|----------------------|----------------------|----------------------|--------------------|\n",
+    "| 200594        | 2020      | 2021-02-16    | Danbury | 8 HICKORY ST         | 121600.0       | 146216.0    | 0.8316463   | Residential   | Single Family    | 25 - Other           | I11192               | HOUSE HAS SETTLED... |            -73.44696 |           40.41404 |\n",
+    "| 200562        | 2020      | 2021-02-03    | Danbury | 19  MILL RD          | 263600.0       | 415000.0    | 0.6351807   | Residential   | Single Family    | 25 - Other           | AFFORDABLE HOUSIN... | INCORRECT DATA PE... |            -23.42596 |           21.41424 |\n",
+    "| 200968        | 2020      | 2021-05-24    | Danbury | 4A FLIRTATION DR     | 205700.0       | 515000.0    | 0.3994175   | Residential   | Single Family    | 07 - Change in Pr... | B17008               | UPDATED KITCHEN P... |            -73.55596 |           48.43564 |\n",
+    "| 200260        | 2020      | 2020-11-23    | Danbury | 32 COALPIT HILL R... | 84900.0        | 181778.0    | 0.4670532   | Residential   | Condo            | 25 - Other           | J16087-4             | MULTIPLE UNIT SALE   |            -75.46666 |           75.56424 |\n",
+    "| 200262        | 2020      | 2020-11-23    | Danbury | 32 COALPIT HILL R... | 84900.0        | 181778.0    | 0.4670532   | Residential   | Condo            | 25 - Other           | J16087-6             | MULTIPLE UNIT SALE   |            -13.44696 |           22.48524 |"
    ]
   },
   {
@@ -613,9 +607,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 on cluster-with-metastore-bq (Remote)",
+   "display_name": "Python 3 on cluster-dpms (Remote)",
    "language": "python",
-   "name": "9b6844836fbacc61a012fc97-python3"
+   "name": "7a42ae6b283a613cfabce6f7-python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -627,7 +621,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.15"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/regression/decision_tree_regression/housing_prices_prediction.ipynb
+++ b/regression/decision_tree_regression/housing_prices_prediction.ipynb
@@ -3,6 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9ebc1564",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "# Copyright 2023 Google LLC\n",
@@ -18,19 +25,20 @@
     "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
     "# See the License for the specific language governing permissions and\n",
     "# limitations under the License."
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "6cf651d6",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "source": [
     "# Housing prices prediction from real estate assessments (Decision Tree Regression)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -51,9 +59,9 @@
     "\n",
     "#### **Steps**\n",
     "Using Spark, \n",
-    "1) It reads the table [State of Connecticut - Real Estate Sales](https://catalog.data.gov/dataset/real-estate-sales-2001-2018) from the **public_datasets** dataset located in the [metastore](../gcp_services/README.md) (notebook should be connected with the public metastore if using this specific dataset).       \n",
+    "1) It reads the table [State of Connecticut - Real Estate Sales](https://catalog.data.gov/dataset/real-estate-sales-2001-2018) from [gs://dataproc-metastore-public-binaries/real_estate_sales](https://console.cloud.google.com/storage/browser/dataproc-metastore-public-binaries/real_estate_sales).  \n",
     "2) It parses process the dataset to choose features and train the ML model (fits the decision tree regression model) to predict a target value.  \n",
-    "    **Features**: list_year, property_type, residential_type, X, Y  \n",
+    "    **Features**: list_year, property_type, residential_type, longitude, latitude  \n",
     "    **Target**: assessed_value  \n",
     "3) It evaluates and plot the results.\n",
     "\n",
@@ -95,11 +103,6 @@
     "  - AI Platform Notebooks Service Agent\n",
     "  - Notebooks Admin\n",
     "  - Vertex AI Administrator\n",
-    "- **Read tables from Dataproc Metastore**\n",
-    "  - Dataproc Metastore Editor\n",
-    "  - Dataproc Metastore Metadata Editor\n",
-    "  - Dataproc Metastore Metadata User\n",
-    "  - Dataproc Metastore Service Agent\n",
     "- **Read files from bucket**\n",
     "  - Storage Object Viewer\n",
     "- **Run Dataproc jobs**\n",
@@ -154,11 +157,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "952801d6-8bbc-48f0-a6af-18f547df0c76",
+   "id": "c4632574-01e1-49ae-8477-d5d92c62654d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "raw_dataset = spark.read.table(\"public_datasets.real_estate_sales\")"
+    "raw_dataset = spark.read.parquet(\"gs://dataproc-metastore-public-binaries/real_estate_sales/\")"
    ]
   },
   {
@@ -178,20 +181,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Transform location struct into 2 columns (X, Y)\n",
-    "processed_raw_dataset = raw_dataset.withColumn(\"X\", col(\"location.col1\").cast(FloatType())).withColumn(\"Y\", col(\"location.col2\").cast(FloatType())).drop(\"location\")\n",
-    "\n",
     "#### Filters\n",
     "filters = [\n",
     "\"residential_type IS NOT NULL AND residential_type != 'Unknown'\",\n",
     "\"property_type IS NOT NULL AND property_type != 'Unknown'\",\n",
     "\"assessed_value IS NOT NULL\",\n",
-    "\"X IS NOT NULL\",\n",
-    "\"Y IS NOT NULL\",\n",
+    "\"longitude IS NOT NULL\",\n",
+    "\"latitude IS NOT NULL\",\n",
     "\"sale_amount IS NOT NULL\"\n",
     "]\n",
     "filters = \" AND \".join(filters)\n",
-    "filtered_dataset = processed_raw_dataset.filter(filters)"
+    "filtered_dataset = raw_dataset.filter(filters)"
    ]
   },
   {
@@ -234,7 +234,7 @@
    "id": "f05e1600-69b9-44de-8b5c-66dcf80155df",
    "metadata": {},
    "source": [
-    "|serial_number|list_year|date_recorded|     town|         address|assessed_value|sale_amount|sales_ratio|property_type|residential_type|non_use_code|assessor_remarks|opm_remarks|        X|       Y|\n",
+    "|serial_number|list_year|date_recorded|     town|         address|assessed_value|sale_amount|sales_ratio|property_type|residential_type|non_use_code|assessor_remarks|opm_remarks|longitude|latitude|\n",
     "|-------------|---------|-------------|---------|----------------|--------------|-----------|-----------|-------------|----------------|------------|----------------|-----------|---------|--------|\n",
     "|       201374|     2020|   2021-04-06|Waterbury| 88 ELLSMERE AVE|       62560.0|   210000.0|     0.2979|  Residential|   Single Family|     Unknown|         Unknown|    Unknown|-72.99548|41.54391|\n",
     "|       200990|     2020|   2021-01-27|Waterbury| 25 MACARTHUR DR|       50110.0|   105000.0|     0.4772|  Residential|   Single Family|     Unknown|         Unknown|    Unknown|-73.03644|41.57748|\n",
@@ -349,9 +349,9 @@
    "outputs": [],
    "source": [
     "target_column = 'assessed_value'\n",
-    "columns = [target_column,'list_year','property_type','residential_type', 'X', 'Y']\n",
+    "columns = [target_column,'list_year','property_type','residential_type', 'longitude', 'latitude']\n",
     "categorical_columns = ['list_year','property_type','residential_type']\n",
-    "feature_columns = ['indexed_list_year','indexed_property_type','indexed_residential_type', 'X', 'Y']\n",
+    "feature_columns = ['indexed_list_year','indexed_property_type','indexed_residential_type', 'longitude', 'latitude']\n",
     "\n",
     "#### Select only relevant columns\n",
     "sub_dataset = pre_processed_dataset.select(*columns)"
@@ -382,7 +382,7 @@
    "id": "b9de2bc5-ebe9-46da-9a7d-22c98f44babb",
    "metadata": {},
    "source": [
-    "|assessed_value|list_year|property_type|residential_type|        X|       Y|\n",
+    "|assessed_value|list_year|property_type|residential_type|longitude|latitude|\n",
     "|--------------|---------|-------------|----------------|---------|--------|\n",
     "|       62560.0|     2020|  Residential|   Single Family|-72.99548|41.54391|\n",
     "|       50110.0|     2020|  Residential|   Single Family|-73.03644|41.57748|\n",
@@ -412,7 +412,7 @@
    "id": "c96398b0-79a9-4e05-aba9-5eddf7fafd2e",
    "metadata": {},
    "source": [
-    "|assessed_value|        X|       Y|indexed_list_year|indexed_property_type|indexed_residential_type|\n",
+    "|assessed_value|longitude|latitude|indexed_list_year|indexed_property_type|indexed_residential_type|\n",
     "|--------------|---------|--------|-----------------|---------------------|------------------------|\n",
     "|       62560.0|-72.99548|41.54391|              0.0|                  1.0|                     0.0|\n",
     "|       50110.0|-73.03644|41.57748|              0.0|                  1.0|                     0.0|\n",
@@ -579,8 +579,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 on cluster-dpms (Remote)",
+   "language": "python",
+   "name": "7a42ae6b283a613cfabce6f7-python3"
+  },
   "language_info": {
-   "name": ""
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/regression/random_forest_regression/bike_trip_duration_prediction.ipynb
+++ b/regression/random_forest_regression/bike_trip_duration_prediction.ipynb
@@ -3,6 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "21406cbb",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "# Copyright 2023 Google LLC\n",
@@ -18,19 +25,20 @@
     "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
     "# See the License for the specific language governing permissions and\n",
     "# limitations under the License."
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "bf6060c9",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "source": [
     "# Bike trip duration prediction"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -95,6 +103,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a392d818",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "#### Import dependencies\n",
@@ -109,10 +124,7 @@
     "\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
@@ -445,9 +457,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "PySpark on cluster-with-metastore-bq (Remote)",
+   "display_name": "Python 3 on cluster-dpms (Remote)",
    "language": "python",
-   "name": "9b6844836fbacc61a012fc97-pyspark"
+   "name": "7a42ae6b283a613cfabce6f7-python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -459,7 +471,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.15"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pandas
 scikit-learn
 google-auth
 google-cloud-storage
+imblearn

--- a/sampling/monte_carlo/customer_price_index.ipynb
+++ b/sampling/monte_carlo/customer_price_index.ipynb
@@ -164,11 +164,6 @@
     "  - AI Platform Notebooks Service Agent\n",
     "  - Notebooks Admin\n",
     "  - Vertex AI Administrator\n",
-    "- **Read tables from Dataproc Metastore**\n",
-    "  - Dataproc Metastore Editor\n",
-    "  - Dataproc Metastore Metadata Editor\n",
-    "  - Dataproc Metastore Metadata User\n",
-    "  - Dataproc Metastore Service Agent\n",
     "- **Read files from bucket**\n",
     "  - Storage Object Viewer\n",
     "- **Run Dataproc jobs**\n",
@@ -192,7 +187,6 @@
    "outputs": [],
    "source": [
     "#### Import dependencies\n",
-    "\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "\n",
@@ -251,7 +245,7 @@
    },
    "outputs": [],
    "source": [
-    "raw_dataset = spark.read.table(\"public_datasets.us_customer_price_index_yearly\")"
+    "raw_dataset = spark.read.option(\"header\",True).csv(\"gs://dataproc-metastore-public-binaries/us_customer_price_index_yearly/\")"
    ]
   },
   {
@@ -608,9 +602,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Curiosity on Serverless Spark (Remote)",
+   "display_name": "Python 3 on cluster-dpms (Remote)",
    "language": "python",
-   "name": "9c39b79e5d2e7072beb4bd59-CURIOSITY"
+   "name": "7a42ae6b283a613cfabce6f7-python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -622,7 +616,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR intends to refactor all notebooks to read the input datasets from the public GCS bucket instead of the public Dataproc Metastore instance to facilitate the usage, since the user can execute the notebook directly from any environment running Spark (that has the GCS connector), instead of having to setup a Dataproc cluster or Serverless Runtime connected to the public Dataproc Metastore. Alternativelly, the user can still opt to read the datasets from the metastore.