### PR TITLE
refactor/gemini requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ We recommend leveraging the [Dataproc Jupyter Plugin](https://github.com/GoogleC
      ```git clone https://github.com/GoogleCloudPlatform/dataproc-ml-quickstart-notebooks.git```
 4) Install requirements by running ```pip install -r requirements.txt```
 5) Start running the notebooks using one of the approaches using the Dataproc Jupyter Plugin:  
-   5.1) Create a Dataproc Serverless Notebooks, after creating a Runtime Template with your desired Dataproc config, and use it as a Jupyter kernel when executing the notebooks    
-   5.2) Create a Dataproc Cluster with your desired Dataproc config, and use it as a Jupyter kernel when executing the notebooks  
+   - 5.1) [**Recommended**] Create **Dataproc Serverless Notebooks**, after creating a **Runtime Template** with your desired Dataproc config, and use it as a Jupyter kernel when executing the notebooks
+        - Do not forget to ensure the correct network [configuration](https://cloud.google.com/dataproc-serverless/docs/concepts/network) (for example, you need a Cloud NAT to be able to install packages from the public PyPI) 
+   - 5.2) Create a **Dataproc Cluster** with your desired Dataproc config, and use it as a Jupyter kernel when executing the notebooks  
 
 ## Contributing
 See the contributing [instructions](./CONTRIBUTING.md) to get started contributing.

--- a/generative_ai/content_generation/description_from_video.ipynb
+++ b/generative_ai/content_generation/description_from_video.ipynb
@@ -300,8 +300,11 @@
     "    )\n",
     "    \n",
     "    text_responses = []\n",
-    "    for response in prediction:\n",
-    "        text_responses.append(response.text)\n",
+    "    try:\n",
+    "        for response in prediction:\n",
+    "            text_responses.append(response.text)\n",
+    "    except:\n",
+    "        pass\n",
     "    return \"\".join(text_responses)"
    ]
   },
@@ -422,9 +425,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "PySpark on cluster-dpms (Remote)",
+   "display_name": "runtime-galileo on Serverless Spark (Remote)",
    "language": "python",
-   "name": "7a42ae6b283a613cfabce6f7-pyspark"
+   "name": "9c39b79e5d2e7072beb4bd59-runtime-galileo"
   },
   "language_info": {
    "codemirror_mode": {
@@ -436,7 +439,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,

--- a/generative_ai/content_generation/description_from_video.ipynb
+++ b/generative_ai/content_generation/description_from_video.ipynb
@@ -135,6 +135,17 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# When using Dataproc Serverless, installed packages are automatically available on all nodes\n",
+    "!pip install --upgrade google-cloud-aiplatform\n",
+    "# When using a Dataproc cluster, you will need to install these packages during cluster creation: https://cloud.google.com/dataproc/docs/tutorials/python-configuration"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "collapsed": false,
@@ -248,15 +259,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "paths_df.show()"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "collapsed": false,
@@ -271,74 +273,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "def generate_descriptions(gcs_uri):\n",
+    "import vertexai\n",
+    "from vertexai.generative_models import GenerativeModel, Part , HarmCategory, HarmBlockThreshold\n",
     "\n",
-    "  def gemini_predict(gcs_uri, prompt):\n",
+    "vertexai.init(project=project_id, location=\"us-central1\")\n",
+    "\n",
+    "def gemini_predict(gcs_uri, prompt):\n",
     "      \n",
-    "    model_url = f\"https://us-central1-aiplatform.googleapis.com/v1/projects/{project_id}/locations/us-central1/publishers/google/models/gemini-pro-vision:streamGenerateContent\"\n",
-    "    request_body = {\n",
-    "      \"contents\": {\n",
-    "        \"role\": \"user\",\n",
-    "        \"parts\": [\n",
-    "          {\n",
-    "            \"fileData\": {\n",
-    "              \"mimeType\": \"video/mp4\",\n",
-    "              \"fileUri\": gcs_uri\n",
-    "            }\n",
-    "          },\n",
-    "          {\n",
-    "            \"text\": prompt\n",
-    "          }\n",
-    "        ]\n",
-    "      },\n",
-    "      \"safety_settings\": {\n",
-    "        \"category\": \"HARM_CATEGORY_SEXUALLY_EXPLICIT\",\n",
-    "        \"threshold\": \"BLOCK_LOW_AND_ABOVE\"\n",
-    "      },\n",
-    "      \"generation_config\": {\n",
-    "        \"temperature\": 0.4,\n",
-    "        \"topP\": 1.0,\n",
-    "        \"topK\": 32,\n",
-    "        \"maxOutputTokens\": 2048\n",
-    "      }\n",
+    "    gemini_pro_vision_model = GenerativeModel(\"gemini-1.0-pro-vision\")\n",
+    "    config = {\"max_output_tokens\": 2048, \"temperature\": 0.4, \"top_p\": 1, \"top_k\": 32}\n",
+    "    safety_config = {\n",
+    "        HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,\n",
+    "        HarmCategory.HARM_CATEGORY_HARASSMENT: HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,\n",
     "    }\n",
-    "      \n",
-    "    prediction = requests.post(\n",
-    "      model_url,\n",
-    "      headers={'Authorization': 'Bearer %s' % credentials.token,\n",
-    "               'Content-Type': 'application/json'},\n",
-    "      json = request_body\n",
-    "    ).json()\n",
-    "\n",
-    "\n",
-    "    full_prediction = \"\"\n",
-    "    for pred in prediction:\n",
-    "      if \"candidates\" in pred:\n",
-    "        content = pred[\"candidates\"][0][\"content\"][\"parts\"][0][\"text\"]\n",
-    "        full_prediction += content\n",
-    "    return full_prediction\n",
-    "\n",
-    "  prompt = f\"\"\"\n",
-    "        Create a short description for this video with the following questions:\n",
-    "         1-) Where the video was from? \n",
-    "         2-) How many people we have? \n",
-    "         3-) What pople are doing? \n",
-    "         4-) whats the proposition for the video?\n",
-    "         5-) A sumary description from the itens 1,2,3 and 4\n",
-    "        Format the 5 descriptions in a JSON format with the KEYS: Where, HowManyPeople, Task, Proposition and Description.\n",
-    "    \"\"\"\n",
-    "\n",
-    "  descriptions = gemini_predict(gcs_uri, prompt)\n",
-    "\n",
-    "  return descriptions"
+    "    \n",
+    "    prediction = gemini_pro_vision_model.generate_content([\n",
+    "          prompt,\n",
+    "          Part.from_uri(gcs_uri, mime_type=\"video/mp4\")\n",
+    "        ],\n",
+    "        generation_config=config,\n",
+    "        safety_settings=safety_config,\n",
+    "        stream=True\n",
+    "    )\n",
+    "    \n",
+    "    text_responses = []\n",
+    "    for response in prediction:\n",
+    "        text_responses.append(response.text)\n",
+    "    return \"\".join(text_responses)"
    ]
   },
   {
@@ -352,6 +316,22 @@
    },
    "outputs": [],
    "source": [
+    "def generate_descriptions(gcs_uri):\n",
+    "    \n",
+    "    prompt = f\"\"\"\n",
+    "        Create a short description for this video with the following questions:\n",
+    "         1) Where the video was from? \n",
+    "         2) How many people we have? \n",
+    "         3) What people are doing? \n",
+    "         4) Whats the proposition for the video?\n",
+    "         5) A sumary description from the itens 1,2,3 and 4\n",
+    "        Format the 5 items as attributes of a JSON object: Where, HowManyPeople, Task, Proposition and Description.\n",
+    "        The response should be a single valid formatted JSON object only.\n",
+    "        \"\"\"\n",
+    "\n",
+    "    descriptions = gemini_predict(gcs_uri, prompt)\n",
+    "    return descriptions\n",
+    "    \n",
     "generate_descriptions_udf = udf(generate_descriptions)"
    ]
   },
@@ -372,9 +352,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df_descriptions.cache()"
@@ -444,9 +422,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "teste4 on Serverless Spark (Remote)",
+   "display_name": "PySpark on cluster-dpms (Remote)",
    "language": "python",
-   "name": "9c39b79e5d2e7072beb4bd59-runtime-0000337f1964"
+   "name": "7a42ae6b283a613cfabce6f7-pyspark"
   },
   "language_info": {
    "codemirror_mode": {
@@ -458,7 +436,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/generative_ai/content_generation/product_attributes_from_image.ipynb
+++ b/generative_ai/content_generation/product_attributes_from_image.ipynb
@@ -453,8 +453,11 @@
     "    )\n",
     "    \n",
     "    text_responses = []\n",
-    "    for response in prediction:\n",
-    "        text_responses.append(response.text)\n",
+    "    try:\n",
+    "        for response in prediction:\n",
+    "            text_responses.append(response.text)\n",
+    "    except:\n",
+    "        pass\n",
     "    return \"\".join(text_responses)"
    ]
   },

--- a/generative_ai/content_generation/product_attributes_from_image.ipynb
+++ b/generative_ai/content_generation/product_attributes_from_image.ipynb
@@ -140,6 +140,17 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# When using Dataproc Serverless, installed packages are automatically available on all nodes\n",
+    "!pip install --upgrade google-cloud-aiplatform\n",
+    "# When using a Dataproc cluster, you will need to install these packages during cluster creation: https://cloud.google.com/dataproc/docs/tutorials/python-configuration"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "collapsed": false,
@@ -313,51 +324,33 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
+    "import vertexai\n",
+    "from vertexai.vision_models import Image, ImageTextModel\n",
+    "\n",
+    "vertexai.init(project=project_id, location=\"us-central1\")\n",
+    "\n",
     "def visual_qa(prompt, gcs_uri):\n",
-    "\n",
-    "  model_url = f\"https://us-central1-aiplatform.googleapis.com/v1/projects/{project_id}/locations/us-central1/publishers/google/models/imagetext:predict\"\n",
-    "\n",
-    "  request = {\n",
-    "      \"instances\": [\n",
-    "        {  \"prompt\": prompt,\n",
-    "            \"image\": {\n",
-    "                 \"gcsUri\": gcs_uri\n",
-    "            }\n",
-    "        }\n",
-    "      ],\n",
-    "      \"parameters\": {\n",
-    "        \"sampleCount\": 1\n",
-    "      }\n",
-    "  }\n",
     "    \n",
-    "  if prompt == \"\": # passing no prompt will trigger the image-captioning to get image description instead of visual-question-answering\n",
-    "    del request[\"instances\"][0][\"prompt\"] \n",
-    "      \n",
-    "  prediction = requests.post( model_url,\n",
-    "    headers={'Authorization': 'Bearer %s' % credentials.token,\n",
-    "             'x-goog-user-project': project_id,\n",
-    "             'Content-Type': 'application/json; charset=utf-8'},\n",
-    "    json=request\n",
-    "  ).json()\n",
+    "    model = ImageTextModel.from_pretrained(\"imagetext@001\")\n",
+    "    source_img = Image(gcs_uri=gcs_uri)\n",
+    "\n",
+    "    if prompt == \"\":\n",
+    "        captions = model.get_captions(\n",
+    "            image=source_img,\n",
+    "            language=\"en\",\n",
+    "            number_of_results=1,\n",
+    "        )\n",
+    "    else:\n",
+    "        captions = model.ask_question(\n",
+    "            image=source_img,\n",
+    "            question=prompt,\n",
+    "            number_of_results=1,\n",
+    "        )\n",
     "    \n",
-    "  if \"predictions\" in prediction:\n",
-    "    return prediction[\"predictions\"][0]\n",
-    "  else:\n",
-    "    if \"error\" in prediction:\n",
-    "      if prediction[\"error\"][\"code\"] == 429:  # Quota exceeded\n",
-    "        time.sleep(5)\n",
-    "        return visual_qa(prompt, gcs_uri)\n",
-    "      else:\n",
-    "        return f\"Error getting prediction: {prediction['error']}\"\n",
-    "    return f\"Error getting predictions\""
+    "    return captions[0]"
    ]
   },
   {
@@ -433,62 +426,47 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
-   },
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import vertexai\n",
+    "from vertexai.generative_models import GenerativeModel, Part , HarmCategory, HarmBlockThreshold\n",
+    "\n",
+    "vertexai.init(project=project_id, location=\"us-central1\")\n",
+    "\n",
+    "def gemini_predict(gcs_uri, prompt):\n",
+    "      \n",
+    "    gemini_pro_vision_model = GenerativeModel(\"gemini-1.0-pro-vision\")\n",
+    "    config = {\"max_output_tokens\": 2048, \"temperature\": 0.4, \"top_p\": 1, \"top_k\": 32}\n",
+    "    safety_config = {\n",
+    "        HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,\n",
+    "        HarmCategory.HARM_CATEGORY_HARASSMENT: HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,\n",
+    "    }\n",
+    "    \n",
+    "    prediction = gemini_pro_vision_model.generate_content([\n",
+    "          prompt,\n",
+    "          Part.from_uri(gcs_uri, mime_type=\"image/jpeg\")\n",
+    "        ],\n",
+    "        generation_config=config,\n",
+    "        safety_settings=safety_config,\n",
+    "        stream=True\n",
+    "    )\n",
+    "    \n",
+    "    text_responses = []\n",
+    "    for response in prediction:\n",
+    "        text_responses.append(response.text)\n",
+    "    return \"\".join(text_responses)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "def generate_descriptions(gcs_uri, description, color, gender, brand, style, material, purpose, year):\n",
-    "\n",
-    "  def gemini_predict(gcs_uri, prompt):\n",
-    "      \n",
-    "    model_url = f\"https://us-central1-aiplatform.googleapis.com/v1/projects/{project_id}/locations/us-central1/publishers/google/models/gemini-pro-vision:streamGenerateContent\"\n",
-    "    request_body = {\n",
-    "      \"contents\": {\n",
-    "        \"role\": \"user\",\n",
-    "        \"parts\": [\n",
-    "          {\n",
-    "            \"fileData\": {\n",
-    "              \"mimeType\": \"image/jpeg\",\n",
-    "              \"fileUri\": gcs_uri\n",
-    "            }\n",
-    "          },\n",
-    "          {\n",
-    "            \"text\": prompt\n",
-    "          }\n",
-    "        ]\n",
-    "      },\n",
-    "      \"safety_settings\": {\n",
-    "        \"category\": \"HARM_CATEGORY_SEXUALLY_EXPLICIT\",\n",
-    "        \"threshold\": \"BLOCK_LOW_AND_ABOVE\"\n",
-    "      },\n",
-    "      \"generation_config\": {\n",
-    "        \"temperature\": 0.4,\n",
-    "        \"topP\": 1.0,\n",
-    "        \"topK\": 32,\n",
-    "        \"maxOutputTokens\": 2048\n",
-    "      }\n",
-    "    }\n",
-    "      \n",
-    "    prediction = requests.post(\n",
-    "      model_url,\n",
-    "      headers={'Authorization': 'Bearer %s' % credentials.token,\n",
-    "               'Content-Type': 'application/json'},\n",
-    "      json = request_body\n",
-    "    ).json()\n",
-    "\n",
-    "\n",
-    "    full_prediction = \"\"\n",
-    "    for pred in prediction:\n",
-    "      if \"candidates\" in pred:\n",
-    "        content = pred[\"candidates\"][0][\"content\"][\"parts\"][0][\"text\"]\n",
-    "        full_prediction += content\n",
-    "    return full_prediction\n",
-    "\n",
-    "  prompt = f\"\"\"\n",
+    "    \n",
+    "    prompt = f\"\"\"\n",
     "        You are a retail expert and knows how to write beatiful, elegant and concise product descriptions, based on data about the product.\n",
     "        Based on the PRODUCT DATA, and the image of the product, you are able to provide the PRODUCT SALES DESCRIPTION.\n",
     "\n",
@@ -527,22 +505,9 @@
     "        PRODUCT SALES DESCRIPTION:\n",
     "    \"\"\"\n",
     "\n",
-    "  descriptions = gemini_predict(gcs_uri, prompt)\n",
-    "\n",
-    "  return descriptions"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
-   },
-   "outputs": [],
-   "source": [
+    "    descriptions = gemini_predict(gcs_uri, prompt)\n",
+    "    return descriptions\n",
+    "    \n",
     "generate_descriptions_udf = udf(generate_descriptions)"
    ]
   },
@@ -590,9 +555,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 on cluster-dpms (Remote)",
+   "display_name": "runtime-galileo on Serverless Spark (Remote)",
    "language": "python",
-   "name": "7a42ae6b283a613cfabce6f7-python3"
+   "name": "9c39b79e5d2e7072beb4bd59-runtime-galileo"
   },
   "language_info": {
    "codemirror_mode": {
@@ -604,7 +569,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,

--- a/generative_ai/sentiment_analysis/sentiment_analysis_movie_reviews.ipynb
+++ b/generative_ai/sentiment_analysis/sentiment_analysis_movie_reviews.ipynb
@@ -27,7 +27,7 @@
    "id": "fe656833-3d7c-4fde-87f5-c7c7ad21a106",
    "metadata": {},
    "source": [
-    "# Sentiment Analysis for large scale data using LLM (PaLM API in Vertex AI)"
+    "# Sentiment Analysis for large scale data using LLM (Gemini)"
    ]
   },
   {
@@ -51,7 +51,7 @@
     "#### **Steps**\n",
     "Using Spark, \n",
     "1) This notebook reads data from Bigquery public dataset **bigquery-public-data.imdb.reviews**\n",
-    "2) It calls [Vertex AI Text Bison](https://cloud.google.com/vertex-ai/docs/generative-ai/start/quickstarts/api-quickstart#try_text_prompts) to find the sentiment of each review (positive vs negative)\n",
+    "2) It calls [Vertex AI Gemini API](https://cloud.google.com/vertex-ai/docs/generative-ai/start/quickstarts/api-quickstart#try_text_prompts) to find the sentiment of each review (positive vs negative)\n",
     "3) We compare the result side by side\n",
     "4) Find accuracy, and again trim the input and observe the accuracy increase\n",
     "\n",
@@ -79,6 +79,18 @@
     "import requests\n",
     "\n",
     "import time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9eb15ebe-c6aa-4f92-92d3-6fa8ec5dc5b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# When using Dataproc Serverless, installed packages are automatically available on all nodes\n",
+    "!pip install --upgrade google-cloud-aiplatform google-cloud-vision\n",
+    "# When using a Dataproc cluster, you will need to install these packages during cluster creation: https://cloud.google.com/dataproc/docs/tutorials/python-configuration"
    ]
   },
   {
@@ -244,71 +256,66 @@
    "id": "2951e16c-5dd3-49b7-abf1-0fbb930453a2",
    "metadata": {},
    "source": [
-    "### Creating a UDF to get predictions from Vertext Text Bison Model\n",
-    "In this method, text whose sentiment is to be predicted is passed. Model used is text-bison-32k which allow 32k input tokens, to accomodate bigger text inputs of movie reviews. "
+    "### Creating a UDF to get predictions from Gemini Model\n",
+    "In this method, text whose sentiment is to be predicted is passed"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9fdfb0bc-8ec1-43ee-b568-96e628772366",
+   "id": "5288e2ee-af06-47ee-a6ce-977852bb700e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import vertexai\n",
+    "from vertexai.generative_models import GenerativeModel, Part , HarmCategory, HarmBlockThreshold\n",
+    "\n",
+    "vertexai.init(project=project_id, location=\"us-central1\")\n",
+    "\n",
+    "def gemini_predict(prompt):\n",
+    "      \n",
+    "    gemini_pro_model = GenerativeModel(\"gemini-1.0-pro\")\n",
+    "    config = {\"max_output_tokens\": 2048, \"temperature\": 0.4, \"top_p\": 1, \"top_k\": 32}\n",
+    "    safety_config = {\n",
+    "        HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,\n",
+    "        HarmCategory.HARM_CATEGORY_HARASSMENT: HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,\n",
+    "    }\n",
+    "    \n",
+    "    prediction = gemini_pro_model.generate_content([\n",
+    "          prompt\n",
+    "        ],\n",
+    "        generation_config=config,\n",
+    "        safety_settings=safety_config,\n",
+    "        stream=True\n",
+    "    )\n",
+    "                    \n",
+    "    text_responses = []\n",
+    "    try:\n",
+    "        for response in prediction:\n",
+    "            text_responses.append(response.text)\n",
+    "    except:\n",
+    "        pass\n",
+    "    return \"\".join(text_responses)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "385d6430-6415-4e16-97c3-b51cd1527395",
    "metadata": {},
    "outputs": [],
    "source": [
     "def find_sentiment_zero_shot(text):\n",
     "    \n",
-    "    def vertex_get_prediction(prompt):\n",
-    "        MODEL_ID=\"text-bison-32k\"\n",
-    "        prediction = requests.post(\n",
-    "            f\"https://us-central1-aiplatform.googleapis.com/v1/projects/{project_id}/locations/us-central1/publishers/google/models/{MODEL_ID}:predict\",\n",
-    "            headers={'Authorization': 'Bearer %s' % credentials.token,\n",
-    "                     'Content-Type': 'application/json'},\n",
-    "            json = {\n",
-    "                      \"instances\": [\n",
-    "                        { \"prompt\": prompt}\n",
-    "                      ],\n",
-    "                      \"parameters\": {\n",
-    "                        \"temperature\": 0.2,\n",
-    "                        \"maxOutputTokens\": 256,\n",
-    "                        \"topK\": 40,\n",
-    "                        \"topP\": 0.95\n",
-    "                    }\n",
-    "            }\n",
-    "        ).json()\n",
-    "        print(prediction)\n",
-    "\n",
-    "        if \"predictions\" in prediction:\n",
-    "            pred = prediction[\"predictions\"][0]\n",
-    "            if \"content\" in pred:\n",
-    "                return pred[\"content\"]\n",
-    "        else:\n",
-    "            if \"error\" in prediction:\n",
-    "                if prediction[\"error\"][\"code\"] == 429:  # Quota exceeded\n",
-    "                    time.sleep(5)\n",
-    "                    return vertex_get_prediction(prompt)\n",
-    "                else:\n",
-    "                    return f\"Error getting prediction: {prediction['error']}\"\n",
-    "\n",
-    "            return f\"Error getting predictions\"\n",
-    "        \n",
     "    prompt = f\"\"\"For the given text below, provide the sentiment classification from the two classes mentioned below:\n",
     "    The two classes are: Negative, Positive.\n",
     "    Always choose between one of them (the most appropriate one.\n",
     "    Text: {text}\n",
     "    Sentiment:\"\"\"\n",
     "    \n",
-    "    sentiment = vertex_get_prediction(prompt)\n",
-    "        \n",
-    "    return sentiment"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "43a2b622-9430-4a3d-9f29-3b6714347550",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "    sentiment = gemini_predict(prompt)\n",
+    "    return sentiment\n",
+    "    \n",
     "find_sentiment_zero_shot_udf = udf(find_sentiment_zero_shot)"
    ]
   },
@@ -337,7 +344,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "movie_review_sentiment_pred = movie_reviews_mixed.withColumn(\"predicted_sentiment\", find_sentiment_zero_shot_udf(movie_reviews_mixed[\"review\"])).cache()"
+    "movie_review_sentiment_pred = movie_reviews_mixed.withColumn(\"predicted_sentiment\", find_sentiment_zero_shot_udf(movie_reviews_mixed[\"review\"]))"
    ]
   },
   {
@@ -366,7 +373,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "trimmed_movie_review_sentiment_pred.select(col(\"predicted_sentiment\"), col(\"label\")).show(truncate=False)"
+    "trimmed_movie_review_sentiment_pred.select(col(\"predicted_sentiment\"), col(\"label\")).show(200,100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5cc405d9-a775-40c9-93e1-3a79a5251837",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trimmed_movie_review_sentiment_pred.cache()"
    ]
   },
   {
@@ -424,7 +441,7 @@
    "id": "36daec26-213d-4a94-9c30-caa4a419ea13",
    "metadata": {},
    "source": [
-    "Without any prior training or chaining prompts, only by zero shot, the model has been able to predict sentiments properly with 86% AUC-ROC"
+    "Without any prior training or chaining prompts, only by zero shot, the model has been able to predict sentiments properly with 94% AUC-ROC"
    ]
   },
   {
@@ -463,9 +480,9 @@
     "#### Percentage Accuracy  \n",
     "\n",
     "Total Rows = 200\n",
-    "* Mislabeled rows = 20\n",
+    "* Mislabeled rows = 10\n",
     "* Accuracy = (True positives + True Negatives)/ (True positives + True negatives + False positives + False negatives)\n",
-    "* Percentage Accuracy= 180 / 200 = 90%"
+    "* Percentage Accuracy= 190 / 200 = 90%"
    ]
   },
   {
@@ -500,9 +517,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 on cluster-dpms (Remote)",
+   "display_name": "runtime-galileo on Serverless Spark (Remote)",
    "language": "python",
-   "name": "7a42ae6b283a613cfabce6f7-python3"
+   "name": "9c39b79e5d2e7072beb4bd59-runtime-galileo"
   },
   "language_info": {
    "codemirror_mode": {
@@ -514,7 +531,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,

--- a/generative_ai/summarization/ocr_contract_summarization_llm.ipynb
+++ b/generative_ai/summarization/ocr_contract_summarization_llm.ipynb
@@ -37,7 +37,7 @@
     }
    },
    "source": [
-    "# Summarize contracts (PDF files) using OCR (Vision API) and LLM (PaLM API)"
+    "# Summarize contracts (PDF files) using OCR (Vision API) and LLM (Gemini)"
    ]
   },
   {
@@ -64,7 +64,7 @@
     "1) It reads the table of the [Contract Understanding Atticus Dataset (CUAD)](https://www.atticusprojectai.org/cuad) dataset located in the [gs://dataproc-metastore-public-binaries/cuad_v1/full_contract_pdf/](https://console.cloud.google.com/storage/browser/dataproc-metastore-public-binaries/cuad_v1)  \n",
     "   We will create a metadata table poiting to the paths of the image files in the bucket.  \n",
     "2) It runs OCR using Vision API - it start a series of async operations and then checks its completion status.\n",
-    "3) It calls [Vertex AI PaLM API](https://cloud.google.com/vertex-ai/docs/generative-ai/start/quickstarts/api-quickstart#try_text_prompts) to summarize each text page.\n",
+    "3) It calls [Vertex AI Gemini API](https://cloud.google.com/vertex-ai/docs/generative-ai/start/quickstarts/api-quickstart#try_text_prompts) to summarize each text page.\n",
     "4) It saves the output to BigQuery\n",
     "\n",
     "#### Related content\n",
@@ -109,7 +109,7 @@
     "- **Run Dataproc jobs**\n",
     "  - Dataproc Service Agent\n",
     "  - Dataproc Worker\n",
-    "- **Call Google APIs (PaLM and Vision)**\n",
+    "- **Call Google APIs (Gemini and Vision)**\n",
     "  - Service Usage Consumer\n",
     "  - VisionAI Admin\n",
     "- **BigQuery**\n",
@@ -147,6 +147,18 @@
     "import requests\n",
     "\n",
     "from google.cloud import storage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37a9e9fc-8b54-48a6-9389-e3ed4ce3cb6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# When using Dataproc Serverless, installed packages are automatically available on all nodes\n",
+    "!pip install --upgrade google-cloud-aiplatform google-cloud-vision\n",
+    "# When using a Dataproc cluster, you will need to install these packages during cluster creation: https://cloud.google.com/dataproc/docs/tutorials/python-configuration"
    ]
   },
   {
@@ -305,49 +317,50 @@
     "tags": []
    },
    "source": [
-    "#### Run OCR - Start async operations"
+    "#### Run OCR - Start operations"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3edd4f41-abef-45ea-ac07-d1b1a2fa311e",
+   "id": "958c6924-2fd3-4bcb-9c68-d965a286c030",
    "metadata": {},
    "outputs": [],
    "source": [
-    "### Spark User Defined Function (UDF)\n",
-    "def perform_ocr(gcs_source_uri, gcs_output_bucket, output_path_prefix):     \n",
+    "from google.cloud import vision_v1 as vision"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0251955c-0343-4195-9534-cc5c720e7935",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def perform_ocr(gcs_source_uri, gcs_output_bucket, output_path_prefix):\n",
     "\n",
     "    gcs_uri, file_name = os.path.split(gcs_source_uri)\n",
     "    sub_paths = re.sub(r\"gs://[^/]+\", \"\", gcs_uri, 1)\n",
     "    gcs_destination_uri = gcs_output_bucket + \"/\" + output_path_prefix + sub_paths + \"/\" + file_name\n",
     "\n",
-    "    operation = requests.post(\n",
-    "            f\"https://us-vision.googleapis.com/v1/projects/{project_id}/locations/us/files:asyncBatchAnnotate\",\n",
-    "            headers={'Authorization': 'Bearer %s' % credentials.token,\n",
-    "                     'x-goog-user-project': project_id,\n",
-    "                     'Content-Type': 'application/json; charset=utf-8'},\n",
-    "            json={ \"requests\":[{\n",
-    "                      \"inputConfig\": {\n",
-    "                        \"gcsSource\": {\n",
-    "                          \"uri\": gcs_source_uri\n",
-    "                        },\n",
-    "                        \"mimeType\": \"application/pdf\"\n",
-    "                      },\n",
-    "                      \"features\": [{\n",
-    "                        \"type\": \"DOCUMENT_TEXT_DETECTION\"\n",
-    "                      }],\n",
-    "                      \"outputConfig\": {\n",
-    "                        \"gcsDestination\": {\n",
-    "                          \"uri\": gcs_destination_uri\n",
-    "                        },\n",
-    "                        \"batchSize\": 100\n",
-    "                      }\n",
-    "                    }]\n",
-    "                }\n",
-    "        ).json()\n",
+    "    # Prepare the asynchronous request\n",
+    "    async_request = vision.AsyncAnnotateFileRequest(\n",
+    "        features=[vision.Feature(type_=vision.Feature.Type.DOCUMENT_TEXT_DETECTION)],\n",
+    "        input_config = vision.InputConfig(\n",
+    "            gcs_source=vision.GcsSource(uri=gcs_source_uri), \n",
+    "            mime_type='application/pdf'\n",
+    "        ),\n",
+    "        output_config = vision.OutputConfig(\n",
+    "            gcs_destination=vision.GcsDestination(uri=gcs_destination_uri),\n",
+    "            batch_size=100\n",
+    "        )\n",
+    "    )\n",
     "\n",
-    "    return [gcs_destination_uri, operation[\"name\"]]"
+    "    # Submit the OCR request and get the operation\n",
+    "    client = vision.ImageAnnotatorClient()\n",
+    "    operation = client.async_batch_annotate_files(requests=[async_request])\n",
+    "\n",
+    "    return [gcs_destination_uri, operation.operation.name]"
    ]
   },
   {
@@ -436,29 +449,26 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "de193592-a521-4e5e-875e-e0bf54b0a293",
+   "id": "47d1fe70-efc1-4ca1-9d33-e5b16089c668",
    "metadata": {},
    "outputs": [],
    "source": [
-    "### Spark User Defined Function (UDF)\n",
     "def check_completion(operation_name):\n",
-    "\n",
-    "    operation = requests.get(\n",
-    "        f\"https://us-vision.googleapis.com/v1/{operation_name}\",\n",
-    "        headers={'Authorization': 'Bearer %s' % credentials.token,\n",
-    "                 'x-goog-user-project': project_id}\n",
-    "    ).json()\n",
+    "    client = vision.ImageAnnotatorClient()\n",
     "    \n",
-    "    if \"done\" in operation and operation[\"done\"]:\n",
-    "        if \"error\" in operation:\n",
-    "            return f'Operation error: code {operation[\"error\"][\"code\"]} and message {operation[\"error\"][\"message\"]}'\n",
-    "        else:\n",
-    "            return \"done\"\n",
-    "    else:\n",
-    "        if (\"error\" in operation):\n",
-    "            return f\"Error getting operation: {operation['error']}\"\n",
-    "        else:\n",
-    "            return \"processing\""
+    "    operation = client.get_operation({'name': operation_name})\n",
+    "\n",
+    "    status_messages = {\n",
+    "        True: 'done',\n",
+    "        False: 'processing',\n",
+    "        'error': lambda op: f'Operation error: code {op.metadata[\"error\"][\"code\"]} and message {op.metadata[\"error\"][\"message\"]}'\n",
+    "    }\n",
+    "\n",
+    "    result = status_messages.get(operation.done, 'unknown')  # Handle unexpected states\n",
+    "    if result == 'error':\n",
+    "        result = result(operation)\n",
+    "        \n",
+    "    return result"
    ]
   },
   {
@@ -616,7 +626,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ocr_df.show(5,5)"
+    "ocr_df.show(5,50)"
    ]
   },
   {
@@ -651,60 +661,64 @@
     "tags": []
    },
    "source": [
-    "## Summarize pages using Palm API"
+    "## Summarize pages using Gemini API"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70925709-3659-48d7-ad2b-83a578bfbf0b",
+   "id": "1678db6b-3a2e-4a42-b411-34e7dbcb95e7",
    "metadata": {},
    "outputs": [],
    "source": [
-    "### Spark User Defined Function (UDF)\n",
+    "import vertexai\n",
+    "from vertexai.generative_models import GenerativeModel, Part , HarmCategory, HarmBlockThreshold\n",
+    "\n",
+    "vertexai.init(project=project_id, location=\"us-central1\")\n",
+    "\n",
+    "def gemini_predict(prompt):\n",
+    "      \n",
+    "    gemini_pro_model = GenerativeModel(\"gemini-1.0-pro\")\n",
+    "    config = {\"max_output_tokens\": 2048, \"temperature\": 0.4, \"top_p\": 1, \"top_k\": 32}\n",
+    "    safety_config = {\n",
+    "        HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,\n",
+    "        HarmCategory.HARM_CATEGORY_HARASSMENT: HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,\n",
+    "    }\n",
+    "    \n",
+    "    prediction = gemini_pro_model.generate_content([\n",
+    "          prompt\n",
+    "        ],\n",
+    "        generation_config=config,\n",
+    "        safety_settings=safety_config,\n",
+    "        stream=True\n",
+    "    )\n",
+    "    \n",
+    "    text_responses = []\n",
+    "    try:\n",
+    "        for response in prediction:\n",
+    "            text_responses.append(response.text)\n",
+    "    except:\n",
+    "        pass\n",
+    "    return \"\".join(text_responses)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4024f4bb-874b-4907-9cc0-8a393be6f5f7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def summarize_page(page):\n",
     "    \n",
-    "    def predict_palm(prompt):\n",
-    "        MODEL_ID=\"text-bison\"\n",
-    "        prediction = requests.post(\n",
-    "            f\"https://us-central1-aiplatform.googleapis.com/v1/projects/{project_id}/locations/us-central1/publishers/google/models/{MODEL_ID}:predict\",\n",
-    "            headers={'Authorization': 'Bearer %s' % credentials.token,\n",
-    "                     'Content-Type': 'application/json'},\n",
-    "            json = {\n",
-    "                      \"instances\": [\n",
-    "                        { \"prompt\": prompt}\n",
-    "                      ],\n",
-    "                      \"parameters\": {\n",
-    "                        \"temperature\": 0.2,\n",
-    "                        \"maxOutputTokens\": 256,\n",
-    "                        \"topK\": 40,\n",
-    "                        \"topP\": 0.95\n",
-    "                    }\n",
-    "            }\n",
-    "        ).json()\n",
-    "        print(prediction)\n",
-    "\n",
-    "        if \"predictions\" in prediction:\n",
-    "            pred = prediction[\"predictions\"][0]\n",
-    "            if \"content\" in pred:\n",
-    "                return pred[\"content\"]\n",
-    "        else:\n",
-    "            if \"error\" in prediction:\n",
-    "                if prediction[\"error\"][\"code\"] == 429:  # Quota exceeded\n",
-    "                    time.sleep(5)\n",
-    "                    return predict_palm(prompt)\n",
-    "                else:\n",
-    "                    return f\"Error getting prediction: {prediction['error']}\"\n",
-    "\n",
-    "            return f\"Error getting predictions\"\n",
-    "        \n",
     "    prompt = f\"\"\"Provide a summary with about two sentences for the following article page:\n",
     "    {page}\n",
     "    Summary:\"\"\"\n",
     "    \n",
-    "    summary = predict_palm(prompt)\n",
-    "        \n",
-    "    return summary"
+    "    summary = gemini_predict(prompt)\n",
+    "    return summary\n",
+    "    \n",
+    "generate_descriptions_udf = udf(summarize_page)"
    ]
   },
   {
@@ -742,11 +756,13 @@
    "id": "a03765e2-f28f-4c04-a2c3-761b6dbc615a",
    "metadata": {},
    "source": [
-    "|  pdf_path|      page|   summary|\n",
-    "|----------|----------|----------|\n",
-    "|gs://da...|THIS AG...|This is...|\n",
-    "|gs://da...|Definit...|(b)    ...|\n",
-    "|gs://da...|- 5- fo...|This se...|"
+    "|                                          pdf_path|                                              page|                                           summary|\n",
+    "|--------------------------------------------------|--------------------------------------------------|--------------------------------------------------|\n",
+    "|gs://dataproc-metastore-public-binaries/cuad_v1...|NON-COMPETITION AGREEMENT AND RIGHT OF FIRST OF...|In an agreement dated May 3, 2006, Glamis Gold ...|\n",
+    "|gs://dataproc-metastore-public-binaries/cuad_v1...|-2-\\nPART 1\\nINTERPRETATION\\nDefinitions\\n1.1\\n...|This agreement defines key terms used throughou...|\n",
+    "|gs://dataproc-metastore-public-binaries/cuad_v1...|-3-\\n(b)\\na reference to a Part means a Part of...|This agreement defines terms and conditions, in...|\n",
+    "|gs://dataproc-metastore-public-binaries/cuad_v1...|-4-\\n(b)\\nadvise, lend money to, guarantee the ...|This agreement between Glamis and Western Coppe...|\n",
+    "|gs://dataproc-metastore-public-binaries/cuad_v1...|-5-\\nfor by monetary award alone. Accordingly, ...|This agreement outlines the remedies available ...|"
    ]
   },
   {
@@ -756,7 +772,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "summaries_df.show(5,10)"
+    "summaries_df.show(5,50)"
    ]
   },
   {
@@ -817,9 +833,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 on cluster-dpms (Remote)",
+   "display_name": "runtime-galileo on Serverless Spark (Remote)",
    "language": "python",
-   "name": "7a42ae6b283a613cfabce6f7-python3"
+   "name": "9c39b79e5d2e7072beb4bd59-runtime-galileo"
   },
   "language_info": {
    "codemirror_mode": {
@@ -831,7 +847,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Refactor notebooks which does API calls to GCP services to not use http requests but the Python sdk methods for these services.
- Adds the installation of these libraries via pip since Dataproc Serverless sessions allows installation of packages on all cluster nodes via pip install (packages become available in the worker nodes to by used from the Spark UDFs)
- Replace PaLM API calls with Gemini API calls